### PR TITLE
FIX Change of position of the slide in|out icon with scroll of the `<Book />` component

### DIFF
--- a/src/components/chapter-index/styles/styles.jsx
+++ b/src/components/chapter-index/styles/styles.jsx
@@ -33,7 +33,7 @@ export const ChapterIndexContainer = styled.div`
           ? slideOut
           : 'none'}
       2s linear;
-    z-index: 1;
+    z-index: 8;
 
     ::-webkit-scrollbar {
       width: 0px;

--- a/src/components/navabar/styles/styles.jsx
+++ b/src/components/navabar/styles/styles.jsx
@@ -30,7 +30,7 @@ export const NavbarContainer = styled.div`
   padding: 0 16px;
   box-shadow: 0px -5px 20px #888888;
   box-sizing: border-box;
-  z-index: 1;
+  z-index: 9;
 `;
 
 export const RightChildContainer = styled.div`

--- a/src/pages/book/index.jsx
+++ b/src/pages/book/index.jsx
@@ -273,7 +273,9 @@ function Book({ ...props }) {
           }
         >
           <span
-            className="slide-in-out-action-button"
+            className={`slide-in-out-action-button ${
+              menuContainerPosition === 'out' ? 'slide-out' : 'slide-in'
+            }`}
             onClick={handleMenuContainerPositionUpdate}
           >
             {menuContainerPosition === 'out' ? '<' : '>'}

--- a/src/pages/book/styles/styles.jsx
+++ b/src/pages/book/styles/styles.jsx
@@ -44,9 +44,8 @@ export const MenuContainer = styled.div`
   top: 0;
 
   .slide-in-out-action-button {
-    position: absolute;
-    top: 10px;
-    right: -15px;
+    position: fixed;
+    top: 60px;
     width: 60px;
     height: 50px;
     display: flex;
@@ -59,10 +58,18 @@ export const MenuContainer = styled.div`
     cursor: pointer;
     background-color: ${BACKGROUND.white};
     box-shadow: 0 0 5px 2px ${BACKGROUND.lightgrey1};
-    z-index: 1;
+    z-index: 7;
 
     &:hover {
       transform: scale(1.1);
+    }
+
+    &.slide-out {
+      left: 210px;
+    }
+
+    &.slide-in {
+      left: -40px;
     }
   }
 


### PR DESCRIPTION
This commit fixes issue that was missed in the last commit 856f071915555f2e6b100fb322ea636e10fc53a2 which was causing the change in position of the slide in|out icon which was supposed to be fixed.

Apply "position: fixed;" property to the slide in|out icon and update the css properties on view change.