### PR TITLE
FIX - Double scrollbar preventing scrolling of the `<Book />` by normalizing `<body />` scrolling behaviour by hiding it

### DIFF
--- a/src/components/normalize/styles/styles.jsx
+++ b/src/components/normalize/styles/styles.jsx
@@ -50,6 +50,9 @@ export const GlobalStyle = createGlobalStyle`
    */ 
   body {
     margin: 0;
+    width:100%;
+    overflow-x:hidden;
+    overflow-y:hidden;
   }
 
   /**

--- a/src/pages/book/index.jsx
+++ b/src/pages/book/index.jsx
@@ -37,7 +37,6 @@ import {
 import {
   Container,
   MenuContainer,
-  BookContainer,
   ChapterContainer,
   OnThisPageContainer,
   UserActionContainer,
@@ -271,7 +270,7 @@ function Book({ ...props }) {
   return (
     <Container>
       <Navbar rightChild={<UserAction />} />
-      <BookContainer>
+      <div className="book-content-container">
         <MenuContainer
           className={
             menuContainerPosition === 'out' ? 'container-out' : 'container-in'
@@ -302,7 +301,7 @@ function Book({ ...props }) {
           )}
         </ChapterContainer>
         <OnThisPageContainer></OnThisPageContainer>
-      </BookContainer>
+      </div>
     </Container>
   );
 }

--- a/src/pages/book/styles/styles.jsx
+++ b/src/pages/book/styles/styles.jsx
@@ -18,21 +18,23 @@ import { BACKGROUND } from '../../../constants/styles/colors.js';
 
 export const Container = styled.div`
   background-color: ${BACKGROUND.lightgrey1};
-  overflow-x: hidden;
   height: fit-content;
   position: relative;
   display: block;
   width: 100%;
   max-width: 2000px;
   margin: auto;
-`;
 
-export const BookContainer = styled.div`
-  display: flex;
-  width: 100%;
-  position: relative;
-  margin-top: 50px;
-  height: 100vh;
+  .book-content-container {
+    overflow-x: hidden;
+    overflow-y: auto;
+    scroll-behaviour: smooth;
+    display: flex;
+    width: 100%;
+    position: relative;
+    margin: 50px 0px;
+    height: calc(100vh - 50px);
+  }
 `;
 
 export const MenuContainer = styled.div`
@@ -70,6 +72,10 @@ export const MenuContainer = styled.div`
 
     &.slide-in {
       left: -40px;
+    }
+
+    @media (min-width: 2000px) {
+      display: none;
     }
   }
 


### PR DESCRIPTION
This commit also includes the following FIX:
  * FIX -  [c9117b2] Content cut off due to top margin - Calculate height for the "book-content-container" for preventing this cutting off behaviour